### PR TITLE
Standalone compilation for PA monitoring program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated binary and log files
+pactl
+*.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+CC=gcc
+CFLAGS=-Wall -Wextra -pedantic -Werror -g
+LIBS=-lpulse -lsndfile
+
+pactl : pactl.c
+	$(CC) $(CFLAGS) -o $@ $< $(LIBS)
+
+clean :
+	rm pactl
+

--- a/README.md
+++ b/README.md
@@ -41,19 +41,16 @@ Build
 ```bash
 git clone https://github.com/himanshub16/music-habits
 cd music-habits
-./setup.sh
+make
 ```
 
 start collecting data
 ```bash
-cd pulseaudio/src
-make pactl
 ./pactl
 ```
 
 view data collected
 ```bash
-cd pulseaudio/src
 tail -f sink*
 ```
 
@@ -61,10 +58,10 @@ generate summary
 ```bash
 # to print summary (notice the file path)
 # duration can be today/yesterday/month/all
-go run generate_report.go -logfile pulseaudio/src/sink_input-firefox.log -duration today
+go run generate_report.go -logfile sink_input-firefox.log -duration today
 
 # to visualize in browser
-go run generate_report.go -logfile pulseaudio/src/sink_input-firefox.log -interactive -port 5000
+go run generate_report.go -logfile sink_input-firefox.log -interactive -port 5000
 ```
 
 ## Why pulseaudio?

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,0 @@
-git clone https://gitlab.freedesktop.org/pulseaudio/pulseaudio.git pulseaudio
-cd pulseaudio
-./autogen.sh
-./configure
-cd src
-make
-cp ../../pactl.c utils/pactl.c


### PR DESCRIPTION
- Removed dependecy on pulse audio core utils by replacing some of
pa_* utility function by standard library ones.
- Clean up some unused variables. The code compiles warning free with
gcc and clang
- Created a Makefile for the C program and removed the setup.sh script
- Update the usage in the README file
- Added a .gitignore file to exclude the generated binary and log files
from being indexed by Git